### PR TITLE
make scipy import optional (issue #25)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
+env:
+   global:
+      - secure: "BzLdQUSTs6dsngJfNGjLtG++Gmi4KzYv7FEwVqUB6pXKnpMIpv+/md2zkH/Lo3UtdioR2SKytXk3/40tCbpUVD2Yjb+yc5WyyeFLQF9KeF2k9gZkmC35iSbTWt9hK+mnkdJidCK5xbfrXEbZx4FpqyDGFl8GCCjJlPOQ/KEcRVQ="
+      - GH_DOC_BRANCH: master
+      - GH_REPOSITORY: github.com/MDAnalysis/GridDataFormats.git
+      - GIT_CI_USER: TravisCI
+      - GIT_CI_EMAIL: TravisCI@mdanalysis.org
+      - MDA_DOCDIR: doc/html
+   matrix:
+   - SETUP=full
+   - SETUP=minimal
 language: python
 python:
   - "2.7"
@@ -17,11 +28,12 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv python=$TRAVIS_PYTHON_VERSION numpy=1.9.2 scipy=0.16.0 nose=1.3.7 six sphinx=1.3
+  - if [[ $SETUP == 'full' ]]; then conda create --yes -q -n pyenv python=$TRAVIS_PYTHON_VERSION numpy=1.9.2 scipy=0.16.0 nose=1.3.7 sphinx=1.3; fi
+  - if [[ $SETUP == 'minimal' ]]; then conda create --yes -q -n pyenv python=$TRAVIS_PYTHON_VERSION numpy=1.9.2 nose=1.3.7 sphinx=1.3; fi
   - source activate pyenv
   - case "$TRAVIS_PYTHON_VERSION" in 2.*) SPECIAL_PACKAGES="mock";; 3.*) SPECIAL_PACKAGES="";; esac
-  - pip install  coveralls tempdir $SPECIAL_PACKAGES
-
+  - pip install coveralls tempdir $SPECIAL_PACKAGES
+  - pip install -v ./
 script:
   - nosetests -v --with-coverage --cover-package gridData --process-timeout=120 --processes=2 gridData
   - |
@@ -37,12 +49,3 @@ after_success:
      test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \
      test "${TRAVIS_BUILD_NUMBER}.1" == "${TRAVIS_JOB_NUMBER}" && \
      bash ./ci/deploy_docs.sh
-
-env:
-   global:
-      - secure: "BzLdQUSTs6dsngJfNGjLtG++Gmi4KzYv7FEwVqUB6pXKnpMIpv+/md2zkH/Lo3UtdioR2SKytXk3/40tCbpUVD2Yjb+yc5WyyeFLQF9KeF2k9gZkmC35iSbTWt9hK+mnkdJidCK5xbfrXEbZx4FpqyDGFl8GCCjJlPOQ/KEcRVQ="
-      - GH_DOC_BRANCH: master
-      - GH_REPOSITORY: github.com/MDAnalysis/GridDataFormats.git
-      - GIT_CI_USER: TravisCI
-      - GIT_CI_EMAIL: TravisCI@mdanalysis.org
-      - MDA_DOCDIR: doc/html

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,20 @@ The rules for this file:
   * accompany each entry with github issue/PR number (Issue #xyz)
 
 ------------------------------------------------------------------------------
+12/11/2015 orbeckst
+
+  * 0.3.2
+
+  Enhancements
+
+  Changes
+
+  * can import without scipy present (scipy.ndimage will only be used
+    on demand when interpolation of a Grid is requested) (issue #25)
+
+  Fixes
+
+
 12/07/2015 orbeckst, richardjgowers
 
   * 0.3.1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README README.rst INSTALL CHANGELOG COPYING COPYING.LESSER AUTHORS
-include ez_setup.py setup.py
+include setup.py
 
 

--- a/gridData/__init__.py
+++ b/gridData/__init__.py
@@ -194,4 +194,4 @@ from . import gOpenMol
 from . import CCP4
 
 __all__ = ['Grid', 'OpenDX', 'gOpenMol', 'CCP4']
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -27,7 +27,9 @@ Classes and functions
 import os
 from six.moves import cPickle, range, zip
 import numpy
-from scipy import ndimage
+
+# For interpolated grids: need scipy.ndimage but we import it only when needed:
+# import scipy
 
 from . import OpenDX
 from . import gOpenMol
@@ -447,6 +449,7 @@ class Grid(object):
         # for scipy >=0.9: should use scipy.interpolate.griddata
         # http://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.griddata.html#scipy.interpolate.griddata
         # (does it work for nD?)
+        import scipy.ndimage
 
         if spline_order is None:
             # must be compatible with whatever :func:`scipy.ndimage.spline_filter` takes.
@@ -463,7 +466,7 @@ class Grid(object):
         except AttributeError:
             _data = data
 
-        coeffs = ndimage.spline_filter(_data, order=spline_order)
+        coeffs = scipy.ndimage.spline_filter(_data, order=spline_order)
         x0 = self.origin
         dx = self.delta
 
@@ -482,12 +485,12 @@ class Grid(object):
             _coordinates = numpy.array(
                 [_transform(coordinates[i], x0[i], dx[i]) for i in range(len(
                     coordinates))])
-            return ndimage.map_coordinates(coeffs,
-                                           _coordinates,
-                                           prefilter=False,
-                                           mode='nearest',
-                                           cval=cval)
-        # mode='wrap' would be ideal but is broken: http://projects.scipy.org/scipy/ticket/796
+            return scipy.ndimage.map_coordinates(coeffs,
+                                                 _coordinates,
+                                                 prefilter=False,
+                                                 mode='nearest',
+                                                 cval=cval)
+        # mode='wrap' would be ideal but is broken: https://github.com/scipy/scipy/issues/1323
         return interpolatedF
 
     def __eq__(self, other):

--- a/gridData/tests/__init__.py
+++ b/gridData/tests/__init__.py
@@ -1,0 +1,11 @@
+# utilities for running the tests
+
+import importlib
+
+def module_not_found(module):
+    try:
+        importlib.import_module(module)
+    except ImportError:
+        return True
+    else:
+        return False

--- a/gridData/tests/test_grid.py
+++ b/gridData/tests/test_grid.py
@@ -1,9 +1,10 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal, dec
 from nose.tools import raises
 
 from gridData import Grid
 
+from ..tests import module_not_found
 
 class TestGrid:
 
@@ -99,6 +100,9 @@ class TestGrid:
         assert_array_equal(centers[-1] - g.origin,
                            (np.array(g.grid.shape) - 1) * self.delta)
 
+
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def test_resample_factor(self):
         g = self.grid.resample_factor(2)
         assert_array_equal(g.delta, np.ones(3) * .5)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst', 'r') as f:
     long_description = f.read()
 
 setup(name="GridDataFormats",
-      version="0.3.1",
+      version="0.3.2",
       description="Reading and writing of data on regular grids in Python",
       long_description=long_description,
       author="Oliver Beckstein",
@@ -26,7 +26,7 @@ setup(name="GridDataFormats",
                    'Topic :: Software Development :: Libraries :: Python Modules',
                      ],
       packages=find_packages(exclude=[]),
-      package_data={},
+      package_data={'gridData': ['tests/*.dx', 'tests/*.ccp4']},
       install_requires=['numpy>=1.0.3', 'six'],
       tests_require=['nose', 'tempdir', 'numpy'],
       # extras can be difficult to install through setuptools and/or


### PR DESCRIPTION
- moved scipy.ndimage into interpolation method of Grid; will only
  be needed when interpolation is required
- added build matrix tests with/without scipy
- decorated tests with dec.skipif(module_not_found('scipy')) (from MDAnalysis)
  (added module_not_found to test/__init__.py; this also means that the tests
  are included in the package)
- release as 0.3.2
- fixes #25