### PR TITLE
set DX array type

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = .
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -T -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,25 +13,6 @@
 
 import sys, os
 
-# for ReadTheDocs
-# https://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
-try:
-    # Python 3.3
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import Mock as MagicMock
-
-class Mock(MagicMock):
-    __all__ = []
-
-    @classmethod
-    def __getattr__(cls, name):
-            return Mock()
-
-MOCK_MODULES = ['numpy', 'scipy']
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/source/gridData/formats.rst
+++ b/doc/source/gridData/formats.rst
@@ -5,7 +5,7 @@ Formats
 
 A limited number of commonly used formats can be read or written. The
 formats are particularly suitable to interface with molecular
-visualization tools such as VMD_ or PyMOL_.
+visualization tools such as VMD_, PyMOL_, or Chimera_.
 
 Adding new formats is not difficult and user-contributed
 format reader/writer can be easily integrated---send a `pull request`_.
@@ -35,6 +35,7 @@ small number of file formats is directly supported.
 .. _pull request: https://github.com/MDAnalysis/GridDataFormats/pulls
 .. _VMD: http://www.ks.uiuc.edu/Research/vmd/
 .. _PyMOL: http://www.pymol.org/
+.. _Chimera: https://www.cgl.ucsf.edu/chimera/
 .. _OpenDX: http://www.opendx.org/
 .. _gOpenMol: http://www.csc.fi/gopenmol/
 .. _CCP4: http://www.ccp4.ac.uk/html/maplib.html#description

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -35,7 +35,7 @@ and enhancement requests through the `issue tracker`_.
    :maxdepth: 1
 
    gridData/overview
-   gridData/formats.rst
+   gridData/formats
    gridData/core
 
 

--- a/gridData/OpenDX.py
+++ b/gridData/OpenDX.py
@@ -377,7 +377,7 @@ class field(DXclass):
             components = dict(positions=None,connections=None,data=None)
         if comments is None:
             comments = ['OpenDX written by gridData.OpenDX',
-                        'from http://github.com/orbeckst/GridDataFormats']
+                        'from https://github.com/MDAnalysis/GridDataFormats']
         elif type(comments) is not list:
             comments = [str(comments)]
         self.id = classid       # can be an arbitrary string

--- a/gridData/OpenDX.py
+++ b/gridData/OpenDX.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2009-2014 Oliver Beckstein <orbeckst@gmail.com>
 # Released under the GNU Lesser General Public License, version 3 or later.
 
-r""":mod:`OpenDX` --- routines to read and write simple OpenDX files
+r""":mod:`~gridData.OpenDX` --- routines to read and write simple OpenDX files
 ================================================================
 
 The OpenDX format for multi-dimensional grid data. OpenDX is a free
@@ -18,6 +18,66 @@ If you want to build a dx object from your data you can either use the
 convenient :class:`~gridData.core.Grid` class from the top level
 module (:class:`gridData.Grid`) or see the lower-level methods
 described below.
+
+
+Reading and writing OpenDX files
+--------------------------------
+
+If you have OpenDX files from other software and you just want to
+**read** it into a Python array then you do not really need to use the
+interface in :mod:`gridData.OpenDX`: just use
+:class:`~gridData.core.Grid` and load the file::
+
+  from gridData import Grid
+  g = Grid("data.dx")
+
+This should work for files produced by common visualization programs
+(VMD_, PyMOL_, Chimera_). The documentation for :mod:`gridData` tells
+you more about what to do with the :class:`~gridData.core.Grid`
+object.
+
+If you want to **write** an OpenDX file then you just use the
+:meth:`gridData.core.Grid.export` method with `file_format="dx"` (or
+just use a filename with extension ".dx")::
+
+  g.export("data.dx")
+
+However, some visualization programs do not implement full OpenDX
+specifications and only read very specific, "OpenDX-like"
+files. :mod:`gridData.OpenDX` tries to be compatible with these
+formats. However, sometimes additional help is needed to write an
+OpenDX file that can be read by a specific software, as described
+below:
+
+Known issues for writing OpenDX files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* PyMOL_ requires OpenDX files with the type specification "double" in
+  the `class array` section (see issue `#35`_). By default (since
+  release 0.4.0), the type is set to the one that most closely
+  approximates the dtype of the numpy array :attr:`Grid.grid`, which
+  holds all data. This is often :class:`numpy.float64`, which will
+  create an OpenDX type "double", which PyMOL will read.
+
+  However, if you want to *force* a specific OpenDX type (such as
+  "float" or "double", see :attr:`gridData.OpenDX.array.dx_types` for
+  available values) then you can use the ``type`` keyword argument::
+
+    g.export("for_pymol.dx", type="double")
+
+  If you always want to be able to read OpenDX files with PyMOL, it is
+  suggested to always export with ``type="double"``.
+
+  .. versionadded:: 0.4.0
+
+
+
+.. _VMD: http://www.ks.uiuc.edu/Research/vmd/
+.. _PyMOL: http://www.pymol.org/
+.. _Chimera: https://www.cgl.ucsf.edu/chimera/
+.. _`#35`: https://github.com/MDAnalysis/GridDataFormats/issues/35
+
+
 
 
 Building a dx object from a numpy array ``A``
@@ -45,7 +105,7 @@ delta
 The DX data type ("type" in the DX file) is determined from the
 :class:`numpy.dtype` of the :class:`numpy.ndarray` that is provided as
 the *grid* (or with the *type* keyword argument to
-:class:`OpenDX.array`).
+:class:`gridData.OpenDX.array`).
 
 For example, to build a :class:`field`::
 
@@ -199,8 +259,9 @@ class array(DXclass):
     .. _Array Objects:
        https://web.archive.org/web/20080808140524/http://opendx.sdsc.edu/docs/html/pages/usrgu068.htm#Header_440
     """
-    # equivalence between DX types and numpy dtypes.name
-    # (round-tripping is not guaranteed to produce identical types)
+    #: conversion from :attr:`numpy.dtype.name` to closest OpenDX array type
+    #: (round-tripping is not guaranteed to produce identical types); not all
+    #: types are supported (e.g., strings are missing)
     np_types = {
         "uint8": "byte",         # DX "unsigned byte" equivalent
         "int8": "signed byte",
@@ -217,6 +278,9 @@ class array(DXclass):
         # numpy "float128 not available, raise error
         # "string" not automatically supported
     }
+    #: conversion from OpenDX type to closest :class:`numpy.dtype`
+    #: (round-tripping is not guaranteed to produce identical types); not all
+    #: types are supported (e.g., strings and conversion to int64 are missing)
     dx_types = {
         "byte": "uint8",
         "unsigned byte": "uint8",

--- a/gridData/OpenDX.py
+++ b/gridData/OpenDX.py
@@ -227,8 +227,6 @@ class array(DXclass):
         "unsigned int": "uint32",
         "int": "int32",
         "signed int": "int32",
-        "unsigned int": "uint64", # not explicit in DX, for compatibility
-        "int": "int64",           # not explicit in DX, for compatibility
         # "hyper",                # ?
         "float": "float32",       # default
         "double": "float64",

--- a/gridData/__init__.py
+++ b/gridData/__init__.py
@@ -99,6 +99,8 @@ The following formats are available (:ref:`supported-file-formats`):
         IBM's Data Explorer, http://www.opendx.org/
    :mod:`~gridData.gOpenMol`
         http://www.csc.fi/gopenmol/
+   :mod:`~gridData.CCP4`
+        CCP4 format http://www.ccp4.ac.uk/html/maplib.html#description
    pickle
         python pickle file (:mod:`pickle`)
 

--- a/gridData/__init__.py
+++ b/gridData/__init__.py
@@ -195,4 +195,4 @@ from . import CCP4
 from . import testing
 
 __all__ = ['Grid', 'OpenDX', 'gOpenMol', 'CCP4', 'testing']
-__version__ = '0.3.3'
+__version__ = '0.4.0-dev'

--- a/gridData/tests/test_ccp4.py
+++ b/gridData/tests/test_ccp4.py
@@ -1,6 +1,6 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import assert_equal
+from numpy.testing import (assert_almost_equal,
+                           assert_equal)
 
 from gridData import Grid
 
@@ -8,7 +8,7 @@ from gridData import Grid
 def test_ccp4():
     g = Grid('gridData/tests/test.ccp4')
     POINTS = 192
-    assert_array_equal(g.grid.flat, np.arange(1, POINTS+1))
+    assert_equal(g.grid.flat, np.arange(1, POINTS+1))
     assert_equal(g.grid.size, POINTS)
-    assert_array_almost_equal(g.delta, [3./4, .5, 2./3])
-    assert_array_equal(g.origin, np.zeros(3))
+    assert_almost_equal(g.delta, [3./4, .5, 2./3])
+    assert_equal(g.origin, np.zeros(3))

--- a/gridData/tests/test_dx.py
+++ b/gridData/tests/test_dx.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal, assert_equal
+from numpy.testing import assert_equal, assert_almost_equal
 
 from nose.tools import raises
 
@@ -12,10 +12,10 @@ from gridData.testing import tempdir
 def test_read_dx():
     g = Grid('gridData/tests/test.dx')
     POINTS = 8
-    assert_array_equal(g.grid.flat, np.ones(POINTS))
+    assert_equal(g.grid.flat, np.ones(POINTS))
     assert_equal(g.grid.size, POINTS)
-    assert_array_equal(g.delta, np.ones(3))
-    assert_array_equal(g.origin, np.zeros(3))
+    assert_equal(g.delta, np.ones(3))
+    assert_equal(g.origin, np.zeros(3))
 
 
 def _test_write_dx(counts=100, ndim=3, nptype="float32", dxtype="float"):
@@ -38,30 +38,51 @@ def _test_write_dx(counts=100, ndim=3, nptype="float32", dxtype="float"):
         data = dx.components['data']
         out_dxtype = data.type
 
-    assert_array_almost_equal(g.grid,
-                              g2.grid,
-                              err_msg="written grid does not match original")
-    assert_array_almost_equal(
-        g.delta,
-        g2.delta,
+    assert_almost_equal(g.grid, g2.grid,
+                        err_msg="written grid does not match original")
+    assert_almost_equal(
+        g.delta, g2.delta,
+        decimal=6,
         err_msg="deltas of written grid do not match original")
 
     assert_equal(out_dxtype, dxtype)
 
 
-def test_write_dx_float(nptype="float32", dxtype="float"):
-    return _test_write_dx(nptype="float32", dxtype="float")
+# conversion from numpy array to DX file
 
-def test_write_dx_double(nptype="float64", dxtype="double"):
+def test_write_dx_float_float16(nptype="float16", dxtype="float"):
     return _test_write_dx(nptype=nptype, dxtype=dxtype)
 
-def test_write_dx_int(nptype="int64", dxtype="int"):
+def test_write_dx_float_float32(nptype="float32", dxtype="float"):
     return _test_write_dx(nptype=nptype, dxtype=dxtype)
 
-def test_write_dx_unsigned_byte(nptype="uint8", dxtype="byte"):
+def test_write_dx_double_float64(nptype="float64", dxtype="double"):
     return _test_write_dx(nptype=nptype, dxtype=dxtype)
 
-# more: see OpenDX.array.types
+def test_write_dx_int_int64(nptype="int64", dxtype="int"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_int_int32(nptype="int32", dxtype="int"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_unsigned_int_uint32(nptype="uint32", dxtype="unsigned int"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_unsigned_int_uint64(nptype="uint64", dxtype="unsigned int"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_short_int16(nptype="int16", dxtype="short"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_unsigned_short_uint16(nptype="uint16", dxtype="unsigned short"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_signed_byte(nptype="int8", dxtype="signed byte"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_byte(nptype="uint8", dxtype="byte"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
 
 @raises(ValueError)
 def test_write_dx_ValueError(nptype="float128", dxtype="unknown"):

--- a/gridData/tests/test_dx.py
+++ b/gridData/tests/test_dx.py
@@ -1,8 +1,11 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import assert_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal, assert_equal
 
+from nose.tools import raises
+
+import gridData.OpenDX
 from gridData import Grid
+
 from gridData.testing import tempdir
 
 
@@ -15,15 +18,25 @@ def test_read_dx():
     assert_array_equal(g.origin, np.zeros(3))
 
 
-def test_write_dx(counts=100, ndim=3):
+def _test_write_dx(counts=100, ndim=3, nptype="float32", dxtype="float"):
     h, edges = np.histogramdd(np.random.random((counts, ndim)), bins=10)
     g = Grid(h, edges)
+
+    # hack the grid to be a different dtype
+    g.grid = g.grid.astype(nptype)
+
     assert_equal(g.grid.sum(), counts)
 
     with tempdir.in_tempdir():
         outfile = "grid.dx"
         g.export(outfile)
         g2 = Grid(outfile)
+
+        # check that dxtype was written
+        dx = gridData.OpenDX.field(0)
+        dx.read(outfile)
+        data = dx.components['data']
+        out_dxtype = data.type
 
     assert_array_almost_equal(g.grid,
                               g2.grid,
@@ -32,3 +45,24 @@ def test_write_dx(counts=100, ndim=3):
         g.delta,
         g2.delta,
         err_msg="deltas of written grid do not match original")
+
+    assert_equal(out_dxtype, dxtype)
+
+
+def test_write_dx_float(nptype="float32", dxtype="float"):
+    return _test_write_dx(nptype="float32", dxtype="float")
+
+def test_write_dx_double(nptype="float64", dxtype="double"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_int(nptype="int64", dxtype="int"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+def test_write_dx_unsigned_byte(nptype="uint8", dxtype="byte"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)
+
+# more: see OpenDX.array.types
+
+@raises(ValueError)
+def test_write_dx_ValueError(nptype="float128", dxtype="unknown"):
+    return _test_write_dx(nptype=nptype, dxtype=dxtype)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst', 'r') as f:
     long_description = f.read()
 
 setup(name="GridDataFormats",
-      version="0.3.3",
+      version="0.4.0-dev",
       description="Reading and writing of data on regular grids in Python",
       long_description=long_description,
       author="Oliver Beckstein",


### PR DESCRIPTION
Issue #35 (and MDAnalysis/mdanalysis#1725) report that DX files written by gridDataFormats cannot be read by PyMOL because PyMOL (wrongly) *hard codes* the expected array type as "double". 

This PR adds a `type` kwarg to `Grid.export()` so that users now have the option to set the output data type to "double" if they so choose; the data are cast to the closest numpy.dtype.

By default, the numpy.dtype of the underlying array is used to set the closest matching DX data type.

