### PR TITLE
use longdouble instead of float128 in test_write_dx_ValueError

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Contributors:
 * Jesse Johnson <holocronweaver> (CCP4 format support)
 * Max Linke <kain88-de>
 * Jan Domanski <jandom>
+* Dominik Mierzejewski <rathann>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,14 @@ The rules for this file:
   * accompany each entry with github issue/PR number (Issue #xyz)
 
 ------------------------------------------------------------------------------
+01/19/2018 rathann
+
+  * 0.4.1
+  
+  Fixes
+  
+  * Fixed testsuite on 32bit architectures (issue #44)
+
 01/17/2017 orbeckst, kain88-de
 
   * 0.4.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'GridDataFormats'
-copyright = u'2007-2017, Oliver Beckstein, Jan Domanski, Max Linke, Jesse Johnson'
+copyright = u'2007-2018, Oliver Beckstein, Jan Domanski, Max Linke, Jesse Johnson, Dominik Mierzejewski'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/gridData/tests/test_dx.py
+++ b/gridData/tests/test_dx.py
@@ -85,5 +85,5 @@ def test_write_dx_byte(nptype="uint8", dxtype="byte"):
 
 
 @raises(ValueError)
-def test_write_dx_ValueError(nptype="float128", dxtype="unknown"):
+def test_write_dx_ValueError(nptype="longdouble", dxtype="unknown"):
     return _test_write_dx(nptype=nptype, dxtype=dxtype)


### PR DESCRIPTION
float128 doesn't exist on 32-bit arches and longdouble maps to float96
there. See also https://github.com/numpy/numpy/issues/5272 .
This fixes issue #44.