### PR TITLE
Updated parsing for DX files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Contributors:
 * Max Linke <kain88-de>
 * Jan Domanski <jandom>
 * Dominik Mierzejewski <rathann>
+* Tyler Luchko <tluchko>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,15 @@ The rules for this file:
   * accompany each entry with github issue/PR number (Issue #xyz)
 
 ------------------------------------------------------------------------------
+07/10/2018 tluchko
+
+  * 0.4.2
+
+  Fixes/Enhancements
+
+  * Fixed reading in DX files containing scientific notation
+  * Improved DX parsing speed
+
 01/19/2018 rathann
 
   * 0.4.1

--- a/gridData/OpenDX.py
+++ b/gridData/OpenDX.py
@@ -775,9 +775,9 @@ class DXParser(object):
             try:
                 while True:
                     # raises exception if not an int
-                    self.__peek().value('int')
+                    self.__peek().value('INTEGER')
                     tok = self.__consume()
-                    shape.append(tok.value('int'))
+                    shape.append(tok.value('INTEGER'))
             except (DXParserNoTokens,ValueError):
                 pass
             if len(shape) == 0:
@@ -830,9 +830,9 @@ class DXParser(object):
             try:
                 while True:
                     # raises exception if not an int
-                    self.__peek().value('int')
+                    self.__peek().value('INTEGER')
                     tok = self.__consume()
-                    shape.append(tok.value('int'))
+                    shape.append(tok.value('INTEGER'))
             except (DXParserNoTokens,ValueError):
                 pass
             if len(shape) == 0:
@@ -867,14 +867,14 @@ class DXParser(object):
         elif tok.equals('rank'):
             tok = self.__consume()
             try:
-                self.currentobject['rank'] = tok.value('int')
+                self.currentobject['rank'] = tok.value('INTEGER')
             except ValueError:
                 raise DXParseError('array: rank was "%s", not an integer.'%\
                                    tok.text)
         elif tok.equals('items'):
             tok = self.__consume()
             try:
-                self.currentobject['size'] = tok.value('int')
+                self.currentobject['size'] = tok.value('INTEGER')
             except ValueError:
                 raise DXParseError('array: items was "%s", not an integer.'%\
                                    tok.text)
@@ -889,9 +889,19 @@ class DXParser(object):
             if not self.currentobject['size']:
                 raise DXParseError("array: missing number of items")
             # This is the slow part.  Once we get here, we are just
-            # reading in a long list of floats but using the parser is expensive.
-            self.currentobject['array'] = [self.__consume().value('REAL') \
-                                           for i in range(self.currentobject['size'])]
+            # reading in a long list of numbers.  Conversion to floats
+            # will be done later when the numpy array is created.
+
+            # Don't assume anything about whitespace or the number of elements per row
+            self.currentobject['array'] = []
+            while len(self.currentobject['array']) <self.currentobject['size']:
+                 self.currentobject['array'].extend(self.dxfile.readline().strip().split())
+
+            # If you assume that there are three elements per row
+            # (except the last) the following version works and is a little faster.
+            # for i in range(int(numpy.ceil(self.currentobject['size']/3))):
+            #     self.currentobject['array'].append(self.dxfile.readline())
+            # self.currentobject['array'] = ' '.join(self.currentobject['array']).split()
         elif tok.equals('attribute'):
             # not used at the moment
             attribute = self.__consume().value()

--- a/gridData/OpenDX.py
+++ b/gridData/OpenDX.py
@@ -605,13 +605,16 @@ class DXParser(object):
     """
 
     # the regexes must match with the categories defined in the Token class
+    # REAL regular expression will catch both integers and floats.
+    # Taken from
+    # https://docs.python.org/3/library/re.html#simulating-scanf
     dx_regex = re.compile(r"""
     (?P<COMMENT>\#.*$)            # comment (until end of line)
     |(?P<WORD>(object|class|counts|origin|delta|type|counts|rank|items|data))
     |"(?P<QUOTEDSTRING>[^\"]*)"   # string in double quotes  (quotes removed)
     |(?P<WHITESPACE>\s+)          # white space
     |(?P<REAL>[-+]?               # true real number (decimal point or
-    (\d+(\.\d*)?|\.\d+)           # scientific notation)
+    (\d+(\.\d*)?|\.\d+)           # scientific notation) and integers
     ([eE][-+]?\d+)?)
     |(?P<BARESTRING>[a-zA-Z_][^\s\#\"]+) # unquoted strings, starting with non-numeric
     """, re.VERBOSE)

--- a/gridData/OpenDX.py
+++ b/gridData/OpenDX.py
@@ -778,7 +778,7 @@ class DXParser(object):
                     self.__peek().value('INTEGER')
                     tok = self.__consume()
                     shape.append(tok.value('INTEGER'))
-            except (DXParserNoTokens,ValueError):
+            except (DXParserNoTokens, ValueError):
                 pass
             if len(shape) == 0:
                 raise DXParseError('gridpositions: no shape parameters')
@@ -833,7 +833,7 @@ class DXParser(object):
                     self.__peek().value('INTEGER')
                     tok = self.__consume()
                     shape.append(tok.value('INTEGER'))
-            except (DXParserNoTokens,ValueError):
+            except (DXParserNoTokens, ValueError):
                 pass
             if len(shape) == 0:
                 raise DXParseError('gridconnections: no shape parameters')

--- a/gridData/tests/test.dx
+++ b/gridData/tests/test.dx
@@ -6,5 +6,5 @@ delta 0 0 1.00
 object 2 class gridconnections counts 2 2 2
 object 3 class array type double rank 0 items 8 data follows
 1.000 1.000 1.000
-1.000 1.000 1.000
+1.000 1.e-6 -1.e6
 1.000 1.000

--- a/gridData/tests/test.dx
+++ b/gridData/tests/test.dx
@@ -1,5 +1,5 @@
 object 1 class gridpositions counts 2 2 2
-origin 0 0 0
+origin 20.1 3e0 -1e1
 delta 1.00 0 0
 delta 0 1.00 0
 delta 0 0 1.00

--- a/gridData/tests/test_dx.py
+++ b/gridData/tests/test_dx.py
@@ -18,7 +18,7 @@ def test_read_dx():
     assert_equal(g.grid.flat, ref)
     assert_equal(g.grid.size, POINTS)
     assert_equal(g.delta, np.ones(3))
-    assert_equal(g.origin, np.array([20.1, 3., -10.])
+    assert_equal(g.origin, np.array([20.1, 3., -10.]))
 
 
 def _test_write_dx(counts=100, ndim=3, nptype="float32", dxtype="float"):

--- a/gridData/tests/test_dx.py
+++ b/gridData/tests/test_dx.py
@@ -14,7 +14,7 @@ def test_read_dx():
     POINTS = 8
     ref = np.ones(POINTS)
     ref[4] = 1e-6
-    ref[5] = 1e+6
+    ref[5] = -1e+6
     assert_equal(g.grid.flat, ref)
     assert_equal(g.grid.size, POINTS)
     assert_equal(g.delta, np.ones(3))

--- a/gridData/tests/test_dx.py
+++ b/gridData/tests/test_dx.py
@@ -12,10 +12,13 @@ from gridData.testing import tempdir
 def test_read_dx():
     g = Grid('gridData/tests/test.dx')
     POINTS = 8
-    assert_equal(g.grid.flat, np.ones(POINTS))
+    ref = np.ones(POINTS)
+    ref[4] = 1e-6
+    ref[5] = 1e+6
+    assert_equal(g.grid.flat, ref)
     assert_equal(g.grid.size, POINTS)
     assert_equal(g.delta, np.ones(3))
-    assert_equal(g.origin, np.zeros(3))
+    assert_equal(g.origin, np.array([20.1, 3., -10.])
 
 
 def _test_write_dx(counts=100, ndim=3, nptype="float32", dxtype="float"):


### PR DESCRIPTION
While using GridDataFormats, I ran into a couple of issues.

1. The library couldn't read in some of the files it produced.  I tracked this down to lines that look like
```
0.0     -1e-06  0.0     
```
In particular, the parser was splitting `-1e-6` into `-1` and `e-6`.  I modified the `FLOAT` regular expression but this required also modifying parts of the code that expected `INTEGER` as all `int`s  are also `float`s.

2. Parsing large files was pretty slow.  On my system, it would take 45 s to read a 74 MB file. I changed just the loop where the data is read to avoid invoking the parser and doing the type casting.  This got the total read time down to about 7 s.  If you are willing to assume that the data has three entries per line (except the last) you can get this down to about 4 s, of which 2 s is spent reading in the data.  My commit has the slower code that doesn't make this assumption and I've commented out the faster version.

For comparison, just reading the file into a list of strings takes about 1.5 s using the code
```
s.extend([line.split() for line in fh])
```
where `s` is an empty list and `fh` is an open file handle.

I wasn't sure how to run your test suite but I've used these changes on many of my own files and they work fine.

Hopefully you find this useful,

Tyler