### PR TITLE
improves inheritance of Grid

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,8 @@ The rules for this file:
   * Added missing floordivision to Grid (PR #53)
   * fix test on ARM (#51)
   * fix incorrect reading of ncstart and nrstart in CCP4 (#57)
+  * fix that arithemtical operations broke inheritance (#56)
+  * fix so that subclasses of ndarray are retained on input (#56)
 
   Changes (do not affect user)
 

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -230,7 +230,7 @@ class Grid(object):
         coordinates = ndmeshgrid(*midpoints)
         # feed a meshgrid to generate all points
         newgrid = self.interpolated(*coordinates)
-        return Grid(newgrid, edges)
+        return self.__class__(newgrid, edges)
 
     def resample_factor(self, factor):
         """Resample to a new regular grid.
@@ -611,21 +611,21 @@ class Grid(object):
 
     def __add__(self, other):
         self.check_compatible(other)
-        return Grid(self.grid + _grid(other), edges=self.edges)
+        return self.__class__(self.grid + _grid(other), edges=self.edges)
 
     def __sub__(self, other):
         self.check_compatible(other)
-        return Grid(self.grid - _grid(other), edges=self.edges)
+        return self.__class__(self.grid - _grid(other), edges=self.edges)
 
     def __mul__(self, other):
         self.check_compatible(other)
-        return Grid(self.grid * _grid(other), edges=self.edges)
+        return self.__class__(self.grid * _grid(other), edges=self.edges)
 
     def __truediv__(self, other):
         # truediv will always do true division (in Python 2 and Python 3);
         # we use from __future__ include division everywhere
         self.check_compatible(other)
-        return Grid(self.grid / _grid(other), edges=self.edges)
+        return self.__class__(self.grid / _grid(other), edges=self.edges)
 
     def __div__(self, other):
         # in Python 2 only (without __future__.division): will do "classic division"
@@ -633,31 +633,31 @@ class Grid(object):
         if not six.PY2:
             raise NotImplementedError("__div__ is only available in Python 2, use __truediv__")
         self.check_compatible(other)
-        return Grid(self.grid.__div__(_grid(other)), edges=self.edges)
+        return self.__class__(self.grid.__div__(_grid(other)), edges=self.edges)
 
     def __floordiv__(self, other):
         self.check_compatible(other)
-        return Grid(self.grid // _grid(other), edges=self.edges)
+        return self.__class__(self.grid // _grid(other), edges=self.edges)
 
     def __pow__(self, other):
         self.check_compatible(other)
-        return Grid(numpy.power(self.grid, _grid(other)), edges=self.edges)
+        return self.__class__(numpy.power(self.grid, _grid(other)), edges=self.edges)
 
     def __radd__(self, other):
         self.check_compatible(other)
-        return Grid(_grid(other) + self.grid, edges=self.edges)
+        return self.__class__(_grid(other) + self.grid, edges=self.edges)
 
     def __rsub__(self, other):
         self.check_compatible(other)
-        return Grid(_grid(other) - self.grid, edges=self.edges)
+        return self.__class__(_grid(other) - self.grid, edges=self.edges)
 
     def __rmul__(self, other):
         self.check_compatible(other)
-        return Grid(_grid(other) * self.grid, edges=self.edges)
+        return self.__class__(_grid(other) * self.grid, edges=self.edges)
 
     def __rtruediv__(self, other):
         self.check_compatible(other)
-        return Grid(_grid(other) / self.grid, edges=self.edges)
+        return self.__class__(_grid(other) / self.grid, edges=self.edges)
 
     def __rdiv__(self, other):
         # in Python 2 only (without __future__.division): will do "classic division"
@@ -665,22 +665,22 @@ class Grid(object):
         if not six.PY2:
             raise NotImplementedError("__rdiv__ is only available in Python 2, use __rtruediv__")
         self.check_compatible(other)
-        return Grid(self.grid.__rdiv__(_grid(other)), edges=self.edges)
+        return self.__class__(self.grid.__rdiv__(_grid(other)), edges=self.edges)
 
     def __rfloordiv__(self, other):
         self.check_compatible(other)
-        return Grid(_grid(other) // self.grid, edges=self.edges)
+        return self.__class__(_grid(other) // self.grid, edges=self.edges)
 
     def __rpow__(self, other):
         self.check_compatible(other)
-        return Grid(numpy.power(_grid(other), self.grid), edges=self.edges)
+        return self.__class__(numpy.power(_grid(other), self.grid), edges=self.edges)
 
     def __repr__(self):
         try:
             bins = self.grid.shape
         except AttributeError:
             bins = "no"
-        return '<Grid with ' + str(bins) + ' bins>'
+        return '<{0} with {1!r} bins>'.format(self.__class__, bins)
 
 
 def ndmeshgrid(*arrs):

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -126,13 +126,13 @@ class Grid(object):
             self.load(grid)
         elif not (grid is None or edges is None):
             # set up from histogramdd-type data
-            self.grid = numpy.asarray(grid)
+            self.grid = numpy.asanyarray(grid)
             self.edges = edges
             self._update()
         elif not (grid is None or origin is None or delta is None):
             # setup from generic data
-            origin = numpy.asarray(origin)
-            delta = numpy.asarray(delta)
+            origin = numpy.asanyarray(origin)
+            delta = numpy.asanyarray(delta)
             if len(origin) != grid.ndim:
                 raise TypeError(
                     "Dimension of origin is not the same as grid dimension.")
@@ -148,7 +148,7 @@ class Grid(object):
             self.edges = [origin[dim] +
                           (numpy.arange(m + 1) - 0.5) * delta[dim]
                           for dim, m in enumerate(grid.shape)]
-            self.grid = numpy.asarray(grid)
+            self.grid = numpy.asanyarray(grid)
             self._update()
         else:
             # empty, must manually populate with load()
@@ -709,7 +709,7 @@ def ndmeshgrid(*arrs):
     for i, arr in enumerate(arrs):
         slc = [1] * dim
         slc[i] = lens[i]
-        arr2 = numpy.asarray(arr).reshape(slc)
+        arr2 = numpy.asanyarray(arr).reshape(slc)
         for j, sz in enumerate(lens):
             if j != i:
                 arr2 = arr2.repeat(sz, axis=j)

--- a/gridData/tests/test_ccp4.py
+++ b/gridData/tests/test_ccp4.py
@@ -60,7 +60,7 @@ def ccp4data():
     ('nlabl', 1),
     ('label', ' Map from fft                                                                   '),
 ])
-def test_ccp4_integer_reading(ccp4data, name, value):
+def test_ccp4_read_header(ccp4data, name, value):
     if type(value) is float:
         assert_almost_equal(ccp4data.header[name], value, decimal=6)
     else:

--- a/gridData/tests/test_grid.py
+++ b/gridData/tests/test_grid.py
@@ -2,24 +2,24 @@ from __future__ import absolute_import, division
 import six
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_almost_equal)
 
 import pytest
 
 from gridData import Grid
 
-class TestGrid(object):
-    @staticmethod
-    @pytest.fixture(scope="class")
-    def data():
-        d = dict(
-            griddata=np.arange(1, 28).reshape(3, 3, 3),
-            origin=np.zeros(3),
-            delta=np.ones(3))
-        d['grid'] = Grid(d['griddata'], origin=d['origin'],
-                         delta=d['delta'])
-        return d
+@pytest.fixture(scope="class")
+def data():
+    d = dict(
+        griddata=np.arange(1, 28).reshape(3, 3, 3),
+        origin=np.zeros(3),
+        delta=np.ones(3))
+    d['grid'] = Grid(d['griddata'], origin=d['origin'],
+                     delta=d['delta'])
+    return d
 
+class TestGrid(object):
     def test_init(self, data):
         g = Grid(data['griddata'], origin=data['origin'],
                  delta=1)
@@ -47,7 +47,7 @@ class TestGrid(object):
         g = g + data['grid']
         assert_array_equal(g.grid.flat, (2 + (2 * data['griddata'])).flat)
 
-    def test_substraction(self, data):
+    def test_subtraction(self, data):
         g = data['grid'] - data['grid']
         assert_array_equal(g.grid.flat, np.zeros(27))
         g = 2 - data['grid']
@@ -140,3 +140,19 @@ class TestGrid(object):
         # check that the edges are the same
         assert_array_almost_equal(g.grid[::5, ::5, ::5],
                                   data['grid'].grid[::2, ::2, ::2])
+
+
+def test_inheritance(data):
+    class DerivedGrid(Grid):
+        pass
+
+    dg = DerivedGrid(data['griddata'], origin=data['origin'],
+                     delta=data['delta'])
+    result = dg + dg - 2.5 * dg / (dg + 5.3)
+
+    assert isinstance(result, DerivedGrid)
+
+    g = data['grid']
+    ref = g + g - 2.5 * g / (dg + 5.3)
+    assert_almost_equal(result.grid, ref.grid)
+

--- a/gridData/tests/test_grid.py
+++ b/gridData/tests/test_grid.py
@@ -9,6 +9,9 @@ import pytest
 
 from gridData import Grid
 
+def f_arithmetic(g):
+    return g + g - 2.5 * g / (g + 5.3)
+
 @pytest.fixture(scope="class")
 def data():
     d = dict(
@@ -148,11 +151,20 @@ def test_inheritance(data):
 
     dg = DerivedGrid(data['griddata'], origin=data['origin'],
                      delta=data['delta'])
-    result = dg + dg - 2.5 * dg / (dg + 5.3)
+    result = f_arithmetic(dg)
 
     assert isinstance(result, DerivedGrid)
 
-    g = data['grid']
-    ref = g + g - 2.5 * g / (dg + 5.3)
+    ref = f_arithmetic(data['grid'])
     assert_almost_equal(result.grid, ref.grid)
 
+def test_anyarray(data):
+    ma = np.ma.MaskedArray(data['griddata'])
+    mg = Grid(ma, origin=data['origin'], delta=data['delta'])
+
+    assert isinstance(mg.grid, ma.__class__)
+
+    result = f_arithmetic(mg)
+    ref = f_arithmetic(data['grid'])
+
+    assert_almost_equal(result.grid, ref.grid)


### PR DESCRIPTION
fixes issue #56 
- arithmetic operations on Grids now properly return an object of its own class (and not just `Grid`)
- input arrays retain their subclass of ndarray (e.g., MaskedArray)