### PR TITLE
Make interpolation outside of known map 0.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Contributors:
 * Eloy Félix <eloyfelix>
 * René Hafner (Hamburger) <renehamburger1993>
 * Lily Wang <lilyminium>
+* Josh Vermaas <jvermaas>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,7 +28,7 @@ The rules for this file:
   * fix multiple __init__ calls (#73)
   * interpolation behavior outside of the grid changed to default to a
     constant rather than the nearest value (#84)
-  * corrected resampling behavior to not draw on values outside of the grid
+  * corrected resampling behavior to not draw on values outside of the grid (#84)
 
 
 05/16/2019 giacomofiorin, orbeckst

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * accompany each entry with github issue/PR number (Issue #xyz)
 
 ------------------------------------------------------------------------------
-??/??/2019 eloyfelix, renehamburger1993, lilyminium
+??/??/2019 eloyfelix, renehamburger1993, lilyminium, jvermaas
 
   * 0.6.0
 
@@ -26,6 +26,8 @@ The rules for this file:
 
   * fix initialization of mutable instance variable of Grid class (metadata dict) (#71)
   * fix multiple __init__ calls (#73)
+  * interpolation behavior outside of the grid changed to default to a
+   constant rather than the nearest value (#84)
 
 
 05/16/2019 giacomofiorin, orbeckst

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,7 +27,8 @@ The rules for this file:
   * fix initialization of mutable instance variable of Grid class (metadata dict) (#71)
   * fix multiple __init__ calls (#73)
   * interpolation behavior outside of the grid changed to default to a
-   constant rather than the nearest value (#84)
+    constant rather than the nearest value (#84)
+  * corrected resampling behavior to not draw on values outside of the grid
 
 
 05/16/2019 giacomofiorin, orbeckst

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -267,8 +267,9 @@ class Grid(object):
         if float(factor) <= 0:
             raise ValueError("Factor must be positive")
         # Determine current spacing
-        spacing = (numpy.array(self._max_edges(
-        )) - numpy.array(self._min_edges())) / (-1 + numpy.array(self._len_edges()))
+        spacing = (numpy.array(self._max_edges()) \
+                   - numpy.array(self._min_edges())) / \
+                  (-1 + numpy.array(self._len_edges())
         # First guess at the new spacing is inversely related to the
         # magnification factor.
         newspacing = spacing / float(factor)

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -650,7 +650,7 @@ class Grid(object):
             return scipy.ndimage.map_coordinates(coeffs,
                                                  _coordinates,
                                                  prefilter=False,
-                                                 mode='nearest',
+                                                 mode='constant',
                                                  cval=cval)
         # mode='wrap' would be ideal but is broken: https://github.com/scipy/scipy/issues/1323
         return interpolatedF

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -268,7 +268,7 @@ class Grid(object):
             raise ValueError("Factor must be positive")
         # Determine current spacing
         spacing = (numpy.array(self._max_edges()) - numpy.array(self._min_edges())) / (
-                  -1 + numpy.array(self._len_edges())
+                  -1 + numpy.array(self._len_edges()))
         # First guess at the new spacing is inversely related to the
         # magnification factor.
         newspacing = spacing / float(factor)

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -187,7 +187,6 @@ class Grid(object):
         self.__interpolation_spline_order = x
         self._update()
 
-
     def resample(self, edges):
         """Resample data to a new grid with edges *edges*.
 
@@ -259,26 +258,31 @@ class Grid(object):
         resample
 
         .. versionchanged:: 0.6.0
-           Previous implementations would not alter the range of the grid edges being resampled on.
-           As a result, values at the grid edges would creep steadily inward. The new implementation
-           recalculates the extent of grid edges for every resampling.
+           Previous implementations would not alter the range of the grid edges
+           being resampled on. As a result, values at the grid edges would creep
+           steadily inward. The new implementation recalculates the extent of
+           grid edges for every resampling.
 
         """
         if float(factor) <= 0:
             ValueError("Factor must be positive")
-        #Determine current spacing
-        spacing = (numpy.array(self._max_edges()) - numpy.array(self._min_edges())) / 
-                (-1 + numpy.array(self._len_edges()))
-        #First guess at the new spacing is inversely related to the magnification factor.
-        newspacing = spacing / float(factor) 
+        # Determine current spacing
+        spacing = (numpy.array(self._max_edges(
+        )) - numpy.array(self._min_edges())) / (-1 + numpy.array(self._len_edges()))
+        # First guess at the new spacing is inversely related to the
+        # magnification factor.
+        newspacing = spacing / float(factor)
         smidpoints = numpy.array(self._midpoints())
-        #We require that the new spacing result in an even subdivision of the existing midpoints
-        newspacing = (smidpoints[:,-1] - smidpoints[:,0]) / 
-                (numpy.maximum(1,numpy.floor((smidpoints[:,-1] - smidpoints[:,0]) / newspacing)))
-        #How many edge points should there be? It is the number of intervals between midpoints + 2
-        edgelength = 2+numpy.round((smidpoints[:,-1]-smidpoints[:,0]) / newspacing)
-        edges = [numpy.linspace(start, stop, num=int(N), endpoint=True)
-                for (start, stop, N) in zip(smidpoints[:,0]-0.5*newspacing, smidpoints[:,-1]+0.5*newspacing, edgelength)]
+        # We require that the new spacing result in an even subdivision of the
+        # existing midpoints
+        newspacing = (smidpoints[:, -1] - smidpoints[:, 0]) / (numpy.maximum(
+            1, numpy.floor((smidpoints[:, -1] - smidpoints[:, 0]) / newspacing)))
+        # How many edge points should there be? It is the number of intervals
+        # between midpoints + 2
+        edgelength = 2 + \
+            numpy.round((smidpoints[:, -1] - smidpoints[:, 0]) / newspacing)
+        edges = [numpy.linspace(start, stop, num=int(N), endpoint=True) for (start, stop, N) in zip(
+            smidpoints[:, 0] - 0.5 * newspacing, smidpoints[:, -1] + 0.5 * newspacing, edgelength)]
         return self.resample(edges)
 
     def _update(self):
@@ -339,7 +343,7 @@ class Grid(object):
 
         Internally, the function uses :func:`scipy.ndimage.map_coordinates`
         with ``mode="constant"`` whereby interpolated values outside
-        the interpolated grid are determined by filling all values beyond 
+        the interpolated grid are determined by filling all values beyond
         the edge with the same constant value, defined by the
         :attr:`interpolation_cval` parameter, which when not set defaults
         to the minimum value in the interpolated grid.
@@ -401,7 +405,13 @@ class Grid(object):
                                                 file_format=file_format,
                                                 export=False)]
 
-    def _load(self, grid=None, edges=None, metadata=None, origin=None, delta=None):
+    def _load(
+            self,
+            grid=None,
+            edges=None,
+            metadata=None,
+            origin=None,
+            delta=None):
         if edges is not None:
             # set up from histogramdd-type data
             self.grid = numpy.asanyarray(grid)
@@ -424,16 +434,17 @@ class Grid(object):
                                 "len(grid.ndim)")
             # note that origin is CENTER so edges must be shifted by -0.5*delta
             self.edges = [origin[dim] +
-                            (numpy.arange(m + 1) - 0.5) * delta[dim]
-                            for dim, m in enumerate(grid.shape)]
+                          (numpy.arange(m + 1) - 0.5) * delta[dim]
+                          for dim, m in enumerate(grid.shape)]
             self.grid = numpy.asanyarray(grid)
             self._update()
         else:
-            raise ValueError("Wrong/missing data to set up Grid. Use Grid() or "
-                                "Grid(grid=<array>, edges=<list>) or "
-                                "Grid(grid=<array>, origin=(x0, y0, z0), delta=(dx, dy, dz)):\n"
-                                "grid={0} edges={1} origin={2} delta={3}".format(
-                                    grid, edges, origin, delta))
+            raise ValueError(
+                "Wrong/missing data to set up Grid. Use Grid() or "
+                "Grid(grid=<array>, edges=<list>) or "
+                "Grid(grid=<array>, origin=(x0, y0, z0), delta=(dx, dy, dz)):\n"
+                "grid={0} edges={1} origin={2} delta={3}".format(
+                    grid, edges, origin, delta))
 
     def load(self, filename, file_format=None):
         """Load saved (pickled or dx) grid and edges from <filename>.pickle
@@ -561,8 +572,7 @@ class Grid(object):
             'File format: http://opendx.sdsc.edu/docs/html/pages/usrgu068.htm#HDREDF',
             'Data are embedded in the header and tied to the grid positions.',
             'Data is written in C array order: In grid[x,y,z] the axis z is fastest',
-            'varying, then y, then finally x, i.e. z is the innermost loop.'
-        ]
+            'varying, then y, then finally x, i.e. z is the innermost loop.']
 
         # write metadata in comments section
         if self.metadata:
@@ -642,7 +652,8 @@ class Grid(object):
         import scipy.ndimage
 
         if spline_order is None:
-            # must be compatible with whatever :func:`scipy.ndimage.spline_filter` takes.
+            # must be compatible with whatever
+            # :func:`scipy.ndimage.spline_filter` takes.
             spline_order = self.interpolation_spline_order
         if cval is None:
             cval = self.interpolation_cval
@@ -685,10 +696,14 @@ class Grid(object):
     def __eq__(self, other):
         if not isinstance(other, Grid):
             return False
-        return numpy.all(other.grid == self.grid) and \
-            numpy.all(other.origin == self.origin) and \
-            numpy.all(numpy.all(other_edge == self_edge) for other_edge, self_edge in
-                      zip(other.edges, self.edges))
+        return numpy.all(
+            other.grid == self.grid) and numpy.all(
+            other.origin == self.origin) and numpy.all(
+            numpy.all(
+                other_edge == self_edge) for other_edge,
+            self_edge in zip(
+                other.edges,
+                self.edges))
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -715,9 +730,13 @@ class Grid(object):
         # in Python 2 only (without __future__.division): will do "classic division"
         # https://docs.python.org/2/reference/datamodel.html#object.__div__
         if not six.PY2:
-            raise NotImplementedError("__div__ is only available in Python 2, use __truediv__")
+            raise NotImplementedError(
+                "__div__ is only available in Python 2, use __truediv__")
         self.check_compatible(other)
-        return self.__class__(self.grid.__div__(_grid(other)), edges=self.edges)
+        return self.__class__(
+            self.grid.__div__(
+                _grid(other)),
+            edges=self.edges)
 
     def __floordiv__(self, other):
         self.check_compatible(other)
@@ -725,7 +744,11 @@ class Grid(object):
 
     def __pow__(self, other):
         self.check_compatible(other)
-        return self.__class__(numpy.power(self.grid, _grid(other)), edges=self.edges)
+        return self.__class__(
+            numpy.power(
+                self.grid,
+                _grid(other)),
+            edges=self.edges)
 
     def __radd__(self, other):
         self.check_compatible(other)
@@ -747,9 +770,13 @@ class Grid(object):
         # in Python 2 only (without __future__.division): will do "classic division"
         # https://docs.python.org/2/reference/datamodel.html#object.__div__
         if not six.PY2:
-            raise NotImplementedError("__rdiv__ is only available in Python 2, use __rtruediv__")
+            raise NotImplementedError(
+                "__rdiv__ is only available in Python 2, use __rtruediv__")
         self.check_compatible(other)
-        return self.__class__(self.grid.__rdiv__(_grid(other)), edges=self.edges)
+        return self.__class__(
+            self.grid.__rdiv__(
+                _grid(other)),
+            edges=self.edges)
 
     def __rfloordiv__(self, other):
         self.check_compatible(other)
@@ -757,7 +784,11 @@ class Grid(object):
 
     def __rpow__(self, other):
         self.check_compatible(other)
-        return self.__class__(numpy.power(_grid(other), self.grid), edges=self.edges)
+        return self.__class__(
+            numpy.power(
+                _grid(other),
+                self.grid),
+            edges=self.edges)
 
     def __repr__(self):
         try:
@@ -780,7 +811,7 @@ def ndmeshgrid(*arrs):
 
     .. SeeAlso: :func:`numpy.meshgrid` for the 2D case.
     """
-    #arrs = tuple(reversed(arrs)) <-- wrong on stackoverflow.com
+    # arrs = tuple(reversed(arrs)) <-- wrong on stackoverflow.com
     arrs = tuple(arrs)
     lens = list(map(len, arrs))
     dim = len(arrs)

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -267,9 +267,8 @@ class Grid(object):
         if float(factor) <= 0:
             raise ValueError("Factor must be positive")
         # Determine current spacing
-        spacing = (numpy.array(self._max_edges()) \
-                   - numpy.array(self._min_edges())) / \
-                  (-1 + numpy.array(self._len_edges())
+        spacing = (numpy.array(self._max_edges()) - numpy.array(self._min_edges())) / (
+                  -1 + numpy.array(self._len_edges())
         # First guess at the new spacing is inversely related to the
         # magnification factor.
         newspacing = spacing / float(factor)

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -265,7 +265,7 @@ class Grid(object):
 
         """
         if float(factor) <= 0:
-            ValueError("Factor must be positive")
+            raise ValueError("Factor must be positive")
         # Determine current spacing
         spacing = (numpy.array(self._max_edges(
         )) - numpy.array(self._min_edges())) / (-1 + numpy.array(self._len_edges()))

--- a/gridData/tests/test_grid.py
+++ b/gridData/tests/test_grid.py
@@ -166,7 +166,10 @@ class TestGrid(object):
 
         g = data['grid'].resample_factor(2)
         assert_array_equal(g.delta, np.ones(3) * .5)
-        assert_array_equal(g.grid.shape, np.ones(3) * 6)
+        # zooming in by a factor of 2. Each subinteral is
+        # split in half, so 3 gridpoints (2 subintervals)
+        # becomes 5 gridpoints (4 subintervals)
+        assert_array_equal(g.grid.shape, np.ones(3) * 5)
         # check that the edges are the same
         assert_array_almost_equal(g.grid[::5, ::5, ::5],
                                   data['grid'].grid[::2, ::2, ::2])

--- a/gridData/tests/test_grid.py
+++ b/gridData/tests/test_grid.py
@@ -166,7 +166,7 @@ class TestGrid(object):
 
         g = data['grid'].resample_factor(2)
         assert_array_equal(g.delta, np.ones(3) * .5)
-        # zooming in by a factor of 2. Each subinteral is
+        # zooming in by a factor of 2. Each subinterval is
         # split in half, so 3 gridpoints (2 subintervals)
         # becomes 5 gridpoints (4 subintervals)
         assert_array_equal(g.grid.shape, np.ones(3) * 5)

--- a/gridData/tests/test_grid.py
+++ b/gridData/tests/test_grid.py
@@ -170,9 +170,10 @@ class TestGrid(object):
         # split in half, so 3 gridpoints (2 subintervals)
         # becomes 5 gridpoints (4 subintervals)
         assert_array_equal(g.grid.shape, np.ones(3) * 5)
-        # check that the edges are the same
-        assert_array_almost_equal(g.grid[::5, ::5, ::5],
-                                  data['grid'].grid[::2, ::2, ::2])
+        # check that the values are identical with the
+        # correct stride.
+        assert_array_almost_equal(g.grid[::2, ::2, ::2],
+                                  data['grid'].grid)
 
     def test_load_pickle(self, data, tmpdir):
         g = data['grid']

--- a/gridData/tests/test_grid.py
+++ b/gridData/tests/test_grid.py
@@ -161,6 +161,12 @@ class TestGrid(object):
         assert_array_equal(centers[-1] - g.origin,
                            (np.array(g.grid.shape) - 1) * data['delta'])
 
+    def test_resample_factor_failure(self, data):
+        pytest.importorskip('scipy')
+
+        with pytest.raises(ValueError):
+            g = data['grid'].resample_factor(0)
+
     def test_resample_factor(self, data):
         pytest.importorskip('scipy')
 


### PR DESCRIPTION
There are instances where "nearest" interpolation leads to some really wild behavior. For instance, I'm trying to add maps together, and the maps themselves are not guaranteed to have zeros along their edges. So when I try summing them together using their interpolated values into a map that is physically larger, extruded volumes of nonzero density stretch out to the edge of the new map. I am not sure under what scenario "nearest" or "wrap" would be correct. For my case, where I am adding together density maps, a "constant" interpolation is correct.

For instance, 

```python
#It is important here that the contents of "somefile" extend to the edge of the grid.
g1 = Grid("somefile")
g2 = Grid("somefile")
g2.origin += 5 #Shift the origin for demonstration purposes to fill the case where two grids have unequal centers.

#We want newG to be g1 + g2. Since the origin is shifted, this will be larger than the original contents of "somefile"
newshape = np.ceil(g2.origin + (g1.grid.shape * g1.delta)  - g1.origin) / g1.delta).astype('int')
neworigin = g1.origin
newG = Grid(grid=np.zeros(newshape, dtype=np.float), origin=neworigin, delta = g1.delta)
newG += g1.resample(newG)
newG += g2.resample(newG)
#At this stage, the "core" density will be right, but you'll see extrusions where the values pulled from the "nearest" interpolation is nonzero.
```

Now if there is some reason why "nearest" should be preferred, please let this behavior be modified through a passed parameter to `resample`.