### PR TITLE
improved docs for core.Grid

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ The rules for this file:
 
   * The new mrc module correctly reorients the coordinate system based
     on mapc, mapr, maps and correctly calculates the origin (issue #76)
+  * documented Grid attributes, including axis convention (issue #69)
 
   Deprecations
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -62,8 +62,5 @@ the `GridDataFormats repository on GitHub`_ and submit a pull request. Participa
    installation	      
    gridData/overview
    gridData/basic
-   gridData/formats
    gridData/core
-
-
-
+   gridData/formats

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -66,9 +66,4 @@ the `GridDataFormats repository on GitHub`_ and submit a pull request. Participa
    gridData/core
 
 
-.. rubric:: Indices and tables
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
 

--- a/gridData/__init__.py
+++ b/gridData/__init__.py
@@ -3,8 +3,9 @@
 # Released under the GNU Lesser General Public License, version 3 or later.
 # See the files COPYING and COPYING.LESSER for details.
 
-""":mod:`gridData` -- Handling grids of data
-=========================================
+r"""
+Handling grids of data --- :mod:`gridData`
+==========================================
 
 Overview
 --------
@@ -17,9 +18,10 @@ we also store the edges, which are are (essentially) the cartesian
 coordinates of the intersections of the grid (mesh) lines on the
 axes. In this way the grid is anchored in space.
 
-The :class:`~gridData.core.Grid` object can be resampled at arbitrary resolution (by
-interpolating the data). Standard algebraic operations are defined for
-grids on a point-wise basis (same as for :class:`numpy.ndarray`).
+The :class:`~gridData.core.Grid` object can be resampled at arbitrary
+resolution (by interpolating the data). Standard algebraic operations
+are defined for grids on a point-wise basis (same as for
+:class:`numpy.ndarray`).
 
 
 Description

--- a/gridData/__init__.py
+++ b/gridData/__init__.py
@@ -3,8 +3,7 @@
 # Released under the GNU Lesser General Public License, version 3 or later.
 # See the files COPYING and COPYING.LESSER for details.
 
-"""
-:mod:`gridData` -- Handling grids of data
+""":mod:`gridData` -- Handling grids of data
 =========================================
 
 Overview
@@ -44,25 +43,26 @@ This is equivalent to knowing
 
 :class:`~gridData.core.Grid` objects have some convenient properties:
 
-* The data is represented as a :class:`numpy.ndarray` and thus shares
-  all the advantages coming with this sophisticated and powerful
-  library.
+* The data is represented as a :class:`numpy.ndarray` in
+  :attr:`Grid.grid<~gridData.core.Grid.grid>` and thus can be directly
+  manipulated with all the tools available in NumPy.
 
-* They can be manipulated arithmetically, e.g. one can simply add or
-  subtract two of them and get another one, or multiply by a
-  constant. Note that all operations are defined point-wise (see the
-  :mod:`numpy` documentation for details) and that only grids defined
-  on the same cell edges can be combined.
+* :class:`Grid` instances can be manipulated arithmetically, e.g. one
+  can simply add or subtract two of them and get another one, or
+  multiply by a constant. Note that all operations are defined
+  point-wise (see the :mod:`numpy` documentation for details) and that
+  only grids defined on the same cell edges can be combined.
 
-* A :class:`~gridData.core.Grid` object can also be created from within python code
-  e.g. from the output of the :func:`numpy.histogramdd` function.
+* A :class:`~gridData.core.Grid` object can also be created from
+  within python code e.g. from the output of the
+  :func:`numpy.histogramdd` function.
 
 * The representation of the data is abstracted from the format that
   the files are saved in. This makes it straightforward to add
   additional readers for new formats.
 
 * The data can be written out again in formats that are understood by
-  other programs such as VMD or PyMOL.
+  other programs such as VMD_, ChimeraX_ or PyMOL_.
 
 
 Reading grid data files
@@ -96,15 +96,21 @@ Formats
 For the available file formats see :ref:`supported-file-formats`.
 
 
+.. _VMD: https://www.ks.uiuc.edu/Research/vmd/
+
+.. _PyMOL: https://pymol.org/
+
+.. _ChimeraX: https://www.cgl.ucsf.edu/chimerax/
 
 """
 
 from .core import Grid
 from . import OpenDX
 from . import gOpenMol
-from . import CCP4
+from . import mrc
+from . import CCP4  # remove in 0.8.0
 
-__all__ = ['Grid', 'OpenDX', 'gOpenMol', 'CCP4']
+__all__ = ['Grid', 'OpenDX', 'gOpenMol', 'mrc', 'CCP4']
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -1,8 +1,8 @@
 # gridDataFormats --- python modules to read and write gridded data
 # Copyright (c) 2009-2014 Oliver Beckstein <orbeckst@gmail.com>
 # Released under the GNU Lesser General Public License, version 3 or later.
-"""
-:mod:`gridData.core` --- Core functionality for storing n-D grids
+r"""
+Core functionality for storing n-D grids --- :mod:`gridData.core`
 =================================================================
 
 The :mod:`core` module contains classes and functions that are
@@ -73,8 +73,8 @@ class Grid(object):
       array) or read data from a filename.
 
     edges : list (optional)
-      list of arrays, the lower and upper bin edges along the axes
-      (such as the output by :func:`numpy.histogramdd`)
+      List of arrays, the lower and upper bin edges along the axes
+      (same as the output by :func:`numpy.histogramdd`)
 
     origin : :class:`numpy.ndarray` (optional)
       Cartesian coordinates of the center of grid position at index
@@ -85,55 +85,73 @@ class Grid(object):
       or ``n x 1`` array for rectangular arrays.
 
     metadata : dict (optional)
-      a user defined dictionary of arbitrary key/value pairs
+      A user defined dictionary of arbitrary key/value pairs
       associated with the density; the class does not touch
       :attr:`metadata` but stores it with :meth:`save`
 
     interpolation_spline_order : int (optional)
-      order of interpolation function for resampling with
+      Order of interpolation function for resampling with
       :func:`resample`; cubic splines = 3 and the default is 3
 
     file_format : str (optional)
-       name of the file format; only necessary when `grid` is a
-       filename (see :meth:`load`) and autodetection of the file
-       format fails. The default is ``None`` and normally the file
-       format is guessed from the file extension.
+      Name of the file format; only necessary when `grid` is a
+      filename (see :meth:`load`) and autodetection of the file
+      format fails. The default is ``None`` and normally the file
+      format is guessed from the file extension.
 
+    Raises
+    ------
+    TypeError
+      If the dimensions of the various input data do not agree with
+      each other.
+    ValueError
+      If some of the required data are not provided in the keyword
+      arguments, e.g., if only the `grid` is supplied as an array but
+      not the `edges` or only `grid` and one of `origin` and `delta`.
+    NotImplementedError
+      If triclinic (non-orthorhombic) boxes are supplied in `delta`
+
+      .. Note:: `delta` can only be a 1D array of length :attr:`grid.ndim`
 
 
     Attributes
     ----------
     grid : :class:`numpy.ndarray`
-       This array can be any number of dimensions supported by NumPy
-       in order to represent high-dimensional data. When used with
-       data that represents real space densities then the **axis
-       convention in GridDataFormats** is that axis 0 corresponds to
-       the Cartesian :math:`x` component, axis 1 corresponds to the
-       :math:`y` component, and axis 2 to the :math:`z` component.
+      This array can be any number of dimensions supported by NumPy
+      in order to represent high-dimensional data. When used with
+      data that represents real space densities then the **axis
+      convention in GridDataFormats** is that axis 0 corresponds to
+      the Cartesian :math:`x` component, axis 1 corresponds to the
+      :math:`y` component, and axis 2 to the :math:`z` component.
 
     delta : :class:`numpy.ndarray`
-       Length of a grid cell (spacing or voxelsize) in x, y, z
-       dimensions. This is a *1D array* with length
-       :attr:`Grid.grid.ndim`.
+      Length of a grid cell (spacing or voxelsize) in :math:`x`,
+      :math:`y`, :math:`z` dimensions. This is a *1D array* with
+      length :attr:`Grid.grid.ndim`.
 
     origin : :class:`numpy.ndarray`
-       array with the Cartesian coordinates of the coordinate system
-       origin, the *center* of cell ``Grid.grid[0, 0, .., 0]``.
+      Array with the Cartesian coordinates of the coordinate system
+      origin, the *center* of cell ``Grid.grid[0, 0, .., 0]``.
 
     edges : list
-       list of arrays, one for each axis in :attr:`grid`.  Each 1D
-       edge array describes the *edges* of the grid cells along the
-       corresponding axis. The length of an edge array for axis ``i``
-       is ``grid.shape[i] + 1`` because it contains the lower boundary
-       for the first cell, the boundaries between all grid cells, and
-       the upper boundary for the last cell. The edges are assumed to
-       be regular with spacing indicated in :attr:`delta`, namely
-       ``Grid.delta[i]`` for axis ``i``.
+      List of arrays, one for each axis in :attr:`grid`.  Each 1D edge
+      array describes the *edges* of the grid cells along the
+      corresponding axis. The length of an edge array for axis ``i``
+      is ``grid.shape[i] + 1`` because it contains the lower boundary
+      for the first cell, the boundaries between all grid cells, and
+      the upper boundary for the last cell. The edges are assumed to
+      be regular with spacing indicated in :attr:`delta`, namely
+      ``Grid.delta[i]`` for axis ``i``.
+
+    midpoints : list
+      List of arrays, one for each axis in :attr:`grid`.  Each 1D
+      midpoints array contains the *midpoints* of the grid cells along
+      the corresponding axis.
 
     metadata : dict
-       A user-defined dictionary that can be used to annotate the
-       data. The content is not touched by :class:`Grid`. It is saved
-       together with the other data with :meth:`save`.
+      A user-defined dictionary that can be used to annotate the
+      data. The content is not touched by :class:`Grid`. It is saved
+      together with the other data with :meth:`save`.
 
 
     Example
@@ -262,7 +280,7 @@ class Grid(object):
         """Resample data to a new grid with edges *edges*.
 
         This method creates a new grid with the data from the current
-        grid resampled to a regular grid specified by *edges*.  The
+        grid resampled to a regular grid specified by `edges`.  The
         order of the interpolation is set by
         :attr:`Grid.interpolation_spline_order`: change the value
         *before* calling :meth:`resample`.
@@ -283,7 +301,7 @@ class Grid(object):
         Examples
         --------
 
-        Providing *edges* (a tuple of three arrays, indicating the
+        Providing `edges` (a tuple of three arrays, indicating the
         boundaries of each grid cell)::
 
           g = grid.resample(edges)
@@ -569,9 +587,9 @@ class Grid(object):
         """export density to file using the given format.
 
         The format can also be deduced from the suffix of the filename
-        though the *format* keyword takes precedence.
+        although the `file_format` keyword takes precedence.
 
-        The default format for export() is 'dx'.  Use 'dx' for
+        The default format for :meth:`export` is 'dx'.  Use 'dx' for
         visualization.
 
         Implemented formats:
@@ -619,7 +637,7 @@ class Grid(object):
         """Pickle the Grid object
 
         The object is dumped as a dictionary with grid and edges: This
-        is sufficient to recreate the grid object with __init__().
+        is sufficient to recreate the grid object with ``__init__()``.
         """
         data = dict(grid=self.grid, edges=self.edges, metadata=self.metadata)
         with open(filename, 'wb') as f:

--- a/gridData/core.py
+++ b/gridData/core.py
@@ -52,74 +52,140 @@ def _grid(x):
 
 
 class Grid(object):
-    """Class to manage a multidimensional grid object.
+    """A multidimensional grid object with origin and grid spacings.
 
-    The export(format='dx') method always exports a 3D object, the
-    rest should work for an array of any dimension.
+    :class:`Grid` objects can be used in arithmetical calculations
+    just like numpy arrays *if* they are compatible, i.e., they have
+    the same shapes and lengths. In order to make arrays compatible,
+    they an be resampled (:meth:`resample`) on a common grid.
 
-    The grid (Grid.grid) can be manipulated as a standard numpy
-    array.
+    The attribute :attr:`grid` that holds the data is a standard numpy
+    array and so the data can be directly manipulated.
 
-    The attribute Grid.metadata holds a user-defined dictionary that
-    can be used to annotate the data. It is saved with save().
+    Data can be read from a number of molecular volume/density formats
+    and written out in different formats with :meth:`export`.
+
+
+    Parameters
+    ----------
+    grid : numpy.ndarray or str (optional)
+      Build the grid either from a histogram or density (a numpy nD
+      array) or read data from a filename.
+
+    edges : list (optional)
+      list of arrays, the lower and upper bin edges along the axes
+      (such as the output by :func:`numpy.histogramdd`)
+
+    origin : :class:`numpy.ndarray` (optional)
+      Cartesian coordinates of the center of grid position at index
+      ``[0, 0, ..., 0]``.
+
+    delta : :class:`numpy.ndarray` (optional)
+      Either ``n x n`` array containing the cell lengths in each dimension,
+      or ``n x 1`` array for rectangular arrays.
+
+    metadata : dict (optional)
+      a user defined dictionary of arbitrary key/value pairs
+      associated with the density; the class does not touch
+      :attr:`metadata` but stores it with :meth:`save`
+
+    interpolation_spline_order : int (optional)
+      order of interpolation function for resampling with
+      :func:`resample`; cubic splines = 3 and the default is 3
+
+    file_format : str (optional)
+       name of the file format; only necessary when `grid` is a
+       filename (see :meth:`load`) and autodetection of the file
+       format fails. The default is ``None`` and normally the file
+       format is guessed from the file extension.
+
+
+
+    Attributes
+    ----------
+    grid : :class:`numpy.ndarray`
+       This array can be any number of dimensions supported by NumPy
+       in order to represent high-dimensional data. When used with
+       data that represents real space densities then the **axis
+       convention in GridDataFormats** is that axis 0 corresponds to
+       the Cartesian :math:`x` component, axis 1 corresponds to the
+       :math:`y` component, and axis 2 to the :math:`z` component.
+
+    delta : :class:`numpy.ndarray`
+       Length of a grid cell (spacing or voxelsize) in x, y, z
+       dimensions. This is a *1D array* with length
+       :attr:`Grid.grid.ndim`.
+
+    origin : :class:`numpy.ndarray`
+       array with the Cartesian coordinates of the coordinate system
+       origin, the *center* of cell ``Grid.grid[0, 0, .., 0]``.
+
+    edges : list
+       list of arrays, one for each axis in :attr:`grid`.  Each 1D
+       edge array describes the *edges* of the grid cells along the
+       corresponding axis. The length of an edge array for axis ``i``
+       is ``grid.shape[i] + 1`` because it contains the lower boundary
+       for the first cell, the boundaries between all grid cells, and
+       the upper boundary for the last cell. The edges are assumed to
+       be regular with spacing indicated in :attr:`delta`, namely
+       ``Grid.delta[i]`` for axis ``i``.
+
+    metadata : dict
+       A user-defined dictionary that can be used to annotate the
+       data. The content is not touched by :class:`Grid`. It is saved
+       together with the other data with :meth:`save`.
+
+
+    Example
+    -------
+    Create a Grid object from data.
+
+    From :func:`numpy.histogramdd`::
+
+      grid, edges = numpy.histogramdd(...)
+      g = Grid(grid, edges=edges)
+
+    From an arbitrary grid::
+
+      g = Grid(grid, origin=origin, delta=delta)
+
+    From a saved file::
+
+      g = Grid(filename)
+
+    or ::
+
+      g = Grid()
+      g.load(filename)
+
+
+    Notes
+    -----
+    In principle, the dimension (number of axes) is arbitrary but in
+    practice many formats only support three and almost all
+    functionality is only tested for this special case.
+
+    The :meth:`export` method with ``format='dx'`` always exports a 3D
+    object. Other methods might work for an array of any dimension (in
+    particular the Python pickle output).
+
+
+    .. versionchanged:: 0.5.0
+       New *file_format* keyword argument.
+
+    .. versionchanged:: 0.7.0
+       CCP4 files are now read with :class:`gridData.mrc.MRC` and not anymore
+       with the deprecated/buggy `ccp4.CCP4`
+
     """
+
+    #: Default format for exporting with :meth:`export`.
     default_format = 'DX'
 
     def __init__(self, grid=None, edges=None, origin=None, delta=None,
                  metadata=None, interpolation_spline_order=3,
                  file_format=None):
-        """
-        Create a Grid object from data.
-
-        From a numpy.histogramdd()::
-
-          grid,edges = numpy.histogramdd(...)
-          g = Grid(grid,edges=edges)
-
-        From an arbitrary grid::
-
-          g = Grid(grid,origin=origin,delta=delta)
-
-        From a saved file::
-
-          g = Grid(filename)
-
-        or ::
-
-          g = Grid()
-          g.load(filename)
-
-        :Arguments:
-          grid
-            histogram or density, defined on numpy nD array, or filename
-          edges
-            list of arrays, the lower and upper bin edges along the axes
-            (both are output by numpy.histogramdd())
-          origin
-            cartesian coordinates of the center of grid[0,0,...,0]
-          delta
-            Either n x n array containing the cell lengths in each dimension,
-            or n x 1 array for rectangular arrays.
-          metadata
-            a user defined dictionary of arbitrary values
-            associated with the density; the class does not touch
-            metadata[] but stores it with save()
-          interpolation_spline_order
-            order of interpolation function for resampling; cubic splines = 3 [3]
-          file_format
-             file format; only necessary when ``grid`` is a filename (see :meth:`Grid.load`);
-             default is ``None`` and the file format is autodetected.
-
-
-        .. versionchanged:: 0.5.0
-           New *file_format* keyword argument.
-
-        .. versionchanged:: 0.7.0
-           CCP4 files are now read with :class:`gridData.mrc.MRC` and not anymore
-           with the deprecated/buggy `ccp4.CCP4`
-
-        """
-        # file formats are guess from extension == lower case key
+        # file formats are guessed from extension == lower case key
         self._exporters = {
             'DX': self._export_dx,
             'PKL': self._export_python,
@@ -255,12 +321,14 @@ class Grid(object):
 
         Returns
         -------
-        Grid
-
+        interpolated grid : Grid
+            The resampled data are represented on a :class:`Grid` with the new
+            grid cell sizes.
 
         See Also
         --------
         resample
+
 
         .. versionchanged:: 0.6.0
            Previous implementations would not alter the range of the grid edges
@@ -353,9 +421,10 @@ class Grid(object):
         :attr:`interpolation_cval` parameter, which when not set defaults
         to the minimum value in the interpolated grid.
 
+
         .. versionchanged:: 0.6.0
            Interpolation outside the grid is now performed with
-           ``mode="constant"`rather than ``mode="nearest"``, eliminating
+           ``mode="constant"`` rather than ``mode="nearest"``, eliminating
            extruded volumes when interpolating beyond the grid.
 
         """
@@ -452,12 +521,9 @@ class Grid(object):
                     grid, edges, origin, delta))
 
     def load(self, filename, file_format=None):
-        """Load saved (pickled or dx) grid and edges from <filename>.pickle
+        """Load saved grid and edges from `filename`
 
-           Grid.load(<filename>.pickle)
-           Grid.load(<filename>.dx)
-
-        The load() method calls the class's constructor method and
+        The :meth:`load` method calls the class's constructor method and
         completely resets all values, based on the loaded data.
         """
         filename = str(filename)
@@ -518,7 +584,6 @@ class Grid(object):
 
         Parameters
         ----------
-
         filename : str
             name of the output file
 
@@ -601,7 +666,7 @@ class Grid(object):
         dx.write(filename)
 
     def save(self, filename):
-        """Save a grid object to <filename>.pickle
+        """Save a grid object to `filename` and add ".pickle" extension.
 
         Internally, this calls
         ``Grid.export(filename, format="python")``. A grid can be
@@ -619,22 +684,46 @@ class Grid(object):
         self.export(filename, file_format="pickle")
 
     def centers(self):
-        """Returns the coordinates of the centers of all grid cells as an
-        iterator."""
+        """Returns the coordinates of the centers of all grid cells as an iterator.
+
+
+        See Also
+        --------
+        :func:`numpy.ndindex`
+        """
         for idx in numpy.ndindex(self.grid.shape):
             yield self.delta * numpy.array(idx) + self.origin
 
     def check_compatible(self, other):
-        """Check if *other* can be used in an arithmetic operation.
+        """Check if `other` can be used in an arithmetic operation.
 
-        1) *other* is a scalar
-        2) *other* is a grid defined on the same edges
+        `other` is compatible if
 
-        :Raises: :exc:`TypeError` if not compatible.
+        1) `other` is a scalar
+        2) `other` is a grid defined on the same edges
+
+        In order to make `other` compatible, resample it on the same
+        grid as this one using :meth:`resample`.
+
+        Parameters
+        ----------
+        other : Grid or float or int
+           Another object to be used for standard arithmetic
+           operations with this :class:`Grid`
+
+        Raises
+        ------
+        TypeError
+              if not compatible
+
+        See Also
+        --------
+        :meth:`resample`
         """
+
         if not (numpy.isreal(other) or self == other):
             raise TypeError(
-                "The argument can not be arithmetically combined with the grid. "
+                "The argument cannot be arithmetically combined with the grid. "
                 "It must be a scalar or a grid with identical edges. "
                 "Use Grid.resample(other.edges) to make a new grid that is "
                 "compatible with other.")

--- a/gridData/mrc.py
+++ b/gridData/mrc.py
@@ -3,7 +3,7 @@
 # Released under the GNU Lesser General Public License, version 3 or later.
 #
 
-""":mod:`mrc` --- the mrc/CCP4 volumetric data format
+""":mod:`mrc` --- the MRC/CCP4 volumetric data format
 ===================================================
 
 .. versionadded:: 0.7.0
@@ -49,6 +49,12 @@ class MRC(object):
     filename : str (optional)
        input file (or stream), can be compressed
 
+    Raises
+    ------
+    ValueError
+       If the unit cell is not orthorhombic or if the data
+       are not volumetric.
+
 
     Attributes
     ----------
@@ -66,7 +72,9 @@ class MRC(object):
 
     origin : numpy.ndarray
        numpy array with coordinates of the coordinate system origin
-       (taken from :attr:`header.origin`)
+       (computed from :attr:`header.origin`, the offsets
+       :attr:`header.origin.nxstart`, :attr:`header.origin.nystart`,
+       :attr:`header.origin.nzstart` and the spacing :attr:`delta`)
 
     rank : int
        The integer 3, denoting that only 3D maps are read.


### PR DESCRIPTION
- fix #69
- document all public attributes
- various text/syntax fixes
- fixed docs for MRC
- added forgotten import of `mrc` to core/__init__.py
- update CHANGELOG