### PR TITLE
bump python to 3.8 for docs action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,13 @@ name: Build and upload to PyPI
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - *
   pull_request:
+    branches:
+      - master
   release:
     types:
       - published
@@ -21,7 +27,7 @@ defaults:
 jobs:
   build_wheels:
     environment: deploy
-    if: "github.repository == 'MDAnalysis/GridDataFormats'"
+    if: "github.repository == 'MDAnalysis/GridDataFormats'" && startsWith
     name: Build pure Python wheel
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   build_wheels:
     environment: deploy
-    if: "github.repository == 'MDAnalysis/GridDataFormats'" && startsWith
+    if: "github.repository == 'MDAnalysis/GridDataFormats'"
     name: Build pure Python wheel
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
     tags:
-      - *
   pull_request:
     branches:
       - master

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,11 +2,7 @@ name: Build and upload to PyPI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - published

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
         auto-update-conda: true
         channel-priority: flexible
         channels: conda-forge


### PR DESCRIPTION
Not sure why that didn't fail in #113...

Anyways whilst I'm bothering you here @orbeckst - are there any docs that outline out griddataformats does a release deployment?

Do you just do a tag and then release / upload to pypi and that's it?