### PR TITLE
Remove pull_request trigger for deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,9 +6,6 @@ on:
       - master
     tags:
       - "*"
-  pull_request:
-    branches:
-      - master
   release:
     types:
       - published


### PR DESCRIPTION
I left it in there originally as a "to check things were running fine", but we should be good now, this will avoid having a ton of "this branch was deployed" messages in PRs that are just confusing in my opinion. It will still run on push to `master` so we should know before a release if there's a problem.