### PR TITLE
updated pypi-publish action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,13 +52,13 @@ jobs:
       - name: publish_testpypi
         # Upload to testpypi on every tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: publish_pypi
         if: github.event_name == 'release' && github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,8 +2,6 @@ name: Build and upload to PyPI
 
 on:
   push:
-    branches:
-      - master
     tags:
       - "*"
   release:


### PR DESCRIPTION
- fix #119
- use pypa/gh-action-pypi-publish@release/v1 as suggested in the deprecation note