### PR TITLE
use MDA docs in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,9 +96,9 @@ welcome. Please fork the repository and submit a `pull request`_.
      :alt: Coverage Status
      :target: https://codecov.io/gh/MDAnalysis/GridDataFormats
 
-.. |docs| image:: https://readthedocs.org/projects/griddataformats/badge/?version=latest
+.. |docs| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
     :alt: Documentation
-    :target: http://griddataformats.readthedocs.org/en/latest/
+    :target: https://www.mdanalysis.org/GridDataFormats/
 
 .. |zenodo| image:: https://zenodo.org/badge/13219/MDAnalysis/GridDataFormats.svg
     :alt: Zenodo DOI


### PR DESCRIPTION
- use our own docs in banner (use io shield)
- removed RTD-generated banner and link